### PR TITLE
Setup stardoc for documentation of the rules

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,3 @@
+# We can't create a bzl_library for rules-swift because of its visibility,
+# so circumvent by not using the sandbox
+build --strategy=Stardoc=standalone

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -11,6 +11,8 @@ jobs:
       - name: Select Xcode 11.2
         run: sudo xcode-select -s /Applications/Xcode_11.2.app
       - name: Install Bazel
-        run: brew install bazel
+        run: brew install bazel buildifier
       - name: Build and Test
         run: bazel test //...
+      - name: buildifier
+        run: find . -type f \( -name 'WORKSPACE' -o -name '*.bzl' -o -name '*.bazel' \) | xargs buildifier --mode=diff

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,22 @@
+genrule(
+    name = "docs",
+    srcs = [
+        "//rules:hmap-docs",
+    ],
+    outs = [
+        "generate_docs.sh",
+    ],
+    cmd = """
+echo "#!/bin/bash" > $(OUTS)
+echo "set -eux" > $(OUTS)
+echo 'function copy() { 
+    dest="$${BUILD_WORKSPACE_DIRECTORY}/docs/$$(basename $$1)"
+    cp "$$1" "$$dest"
+    chmod +w "$$dest"
+}' >> $(OUTS)
+for s in $(SRCS); do
+    echo "copy '$$s'" >> $(OUTS)
+done
+    """,
+    executable = 1,
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -43,3 +43,13 @@ load(
 )
 
 protobuf_deps()
+
+git_repository(
+    name = "io_bazel_stardoc",
+    remote = "https://github.com/bazelbuild/stardoc.git",
+    tag = "0.4.0",
+)
+
+load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+
+stardoc_repositories()

--- a/docs/hmap_doc.md
+++ b/docs/hmap_doc.md
@@ -1,0 +1,29 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+<a name="#headermap"></a>
+
+## headermap
+
+<pre>
+headermap(<a href="#headermap-name">name</a>, <a href="#headermap-flatten_headers">flatten_headers</a>, <a href="#headermap-hdr_providers">hdr_providers</a>, <a href="#headermap-hdrs">hdrs</a>, <a href="#headermap-namespace">namespace</a>)
+</pre>
+
+Creates a binary headermap file from the given headers,
+suitable for passing to clang.
+
+This can be used to allow headers to be imported at a consistent path,
+regardless of the package structure being used.
+    
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| flatten_headers |  Whether headers should be importable with the namespace as a prefix   | Boolean | required |  |
+| hdr_providers |  Targets that provide headers. Targets must have either an Objc or CcInfo provider.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| hdrs |  The list of headers included in the headermap   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
+| namespace |  The prefix to be used for header imports when flatten_headers is true   | String | required |  |
+
+

--- a/rules/BUILD.bazel
+++ b/rules/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "rules-swift",
+    srcs = [
+        "@build_bazel_rules_swift//swift:swift.bzl",
+    ],
+    deps = [
+        "@bazel_skylib//:bzl_library",
+    ],
+)
+
+[
+    stardoc(
+        name = "%s-docs" % name,
+        out = "%s_doc.md" % name,
+        input = "%s.bzl" % name,
+        visibility = ["//:__pkg__"],
+        deps = [":rules-swift"],
+    )
+    for name in [paths.split_extension(p)[0] for p in glob(["*.bzl"])]
+]

--- a/rules/hmap.bzl
+++ b/rules/hmap.bzl
@@ -71,6 +71,7 @@ def _make_headermap_impl(ctx):
             if SwiftInfo in hdr_provider and hdr.path.endswith("-Swift.h"):
                 namespace = ctx.attr.namespace
                 basename = hdr.basename
+
                 # Only propogate the Swift header from this module
                 # The name of the swift header may be -Swift.h or _Swift-Swift.h
                 # dur to bazelizer generated rule naming convention.
@@ -142,7 +143,7 @@ headermap = rule(
         "hdrs": attr.label_list(
             mandatory = True,
             allow_files = True,
-            doc = "The list of headers included in the headermap"
+            doc = "The list of headers included in the headermap",
         ),
         "flatten_headers": attr.bool(
             mandatory = True,
@@ -170,5 +171,5 @@ suitable for passing to clang.
 
 This can be used to allow headers to be imported at a consistent path,
 regardless of the package structure being used.
-    """
+    """,
 )


### PR DESCRIPTION
Run `bazel run docs` to generate the docs and move them into `docs/`