### PR TITLE
Allow packaging empty frameworks, and skipping certain parts of packaging

### DIFF
--- a/docs/framework_doc.md
+++ b/docs/framework_doc.md
@@ -5,7 +5,7 @@
 ## apple_framework_packaging
 
 <pre>
-apple_framework_packaging(<a href="#apple_framework_packaging-name">name</a>, <a href="#apple_framework_packaging-deps">deps</a>, <a href="#apple_framework_packaging-framework_name">framework_name</a>, <a href="#apple_framework_packaging-transitive_deps">transitive_deps</a>)
+apple_framework_packaging(<a href="#apple_framework_packaging-name">name</a>, <a href="#apple_framework_packaging-deps">deps</a>, <a href="#apple_framework_packaging-framework_name">framework_name</a>, <a href="#apple_framework_packaging-skip_packaging">skip_packaging</a>, <a href="#apple_framework_packaging-transitive_deps">transitive_deps</a>)
 </pre>
 
 Packages compiled code into an Apple .framework package
@@ -18,6 +18,7 @@ Packages compiled code into an Apple .framework package
 | name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | deps |  Objc or Swift rules to be packed by the framework rule   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
 | framework_name |  Name of the framework, usually the same as the module name   | String | required |  |
+| skip_packaging |  Parts of the framework packaging process to be skipped. Valid values are: - "binary" - "modulemap" - "header" - "private_header" - "swiftmodule" - "swiftdoc"   | List of strings | optional | [] |
 | transitive_deps |  Deps of the deps   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
 
 
@@ -29,7 +30,7 @@ Packages compiled code into an Apple .framework package
 apple_framework(<a href="#apple_framework-name">name</a>, <a href="#apple_framework-apple_library">apple_library</a>, <a href="#apple_framework-kwargs">kwargs</a>)
 </pre>
 
-    Builds and packages an Apple framework.
+Builds and packages an Apple framework.
 
 **PARAMETERS**
 


### PR DESCRIPTION
This is helpful for two scenarios, but given the same refactor made both possible they're clumped together:

(a) prebuilt libraries that specify public & private headers can now be packaged as a framework so imports work as expected

and (b) creating a better framework for tests to import their test host, but without double linking issues