### PR TITLE
Allow customizing which resource extensions are filtered

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -166,7 +166,7 @@ def generate_resource_bundles(name, library_tools, module_name, resource_bundles
             name = target_name,
             bundle_name = bundle_name,
             resources = [
-                library_tools['wrap_resources_in_filegroup'](name = target_name + "_resources", srcs = resource_bundles[bundle_name]),
+                library_tools["wrap_resources_in_filegroup"](name = target_name + "_resources", srcs = resource_bundles[bundle_name]),
             ],
             infoplists = [name + ".info.plist"],
         )
@@ -446,7 +446,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, **kwa
         weak_sdk_frameworks = weak_sdk_frameworks,
         sdk_includes = sdk_includes,
         pch = pch,
-        data = [library_tools['wrap_resources_in_filegroup'](name = objc_libname + "_data", srcs = data)],
+        data = [library_tools["wrap_resources_in_filegroup"](name = objc_libname + "_data", srcs = data)],
         **kwargs
     )
     lib_names += [objc_libname]

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -166,7 +166,7 @@ def generate_resource_bundles(name, library_tools, module_name, resource_bundles
             name = target_name,
             bundle_name = bundle_name,
             resources = [
-                wrap_resources_in_filegroup(name = target_name + "_resources", srcs = resource_bundles[bundle_name]),
+                library_tools['wrap_resources_in_filegroup'](name = target_name + "_resources", srcs = resource_bundles[bundle_name]),
             ],
             infoplists = [name + ".info.plist"],
         )
@@ -177,6 +177,7 @@ _DefaultLibraryTools = {
     "modulemap_generator": write_modulemap,
     "umbrella_header_generator": write_umbrella_header,
     "resource_bundle_generator": generate_resource_bundles,
+    "wrap_resources_in_filegroup": wrap_resources_in_filegroup,
 }
 
 def _uppercase_string(s):
@@ -445,7 +446,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, **kwa
         weak_sdk_frameworks = weak_sdk_frameworks,
         sdk_includes = sdk_includes,
         pch = pch,
-        data = [wrap_resources_in_filegroup(name = objc_libname + "_data", srcs = data)],
+        data = [library_tools['wrap_resources_in_filegroup'](name = objc_libname + "_data", srcs = data)],
         **kwargs
     )
     lib_names += [objc_libname]

--- a/rules/library/resources.bzl
+++ b/rules/library/resources.bzl
@@ -1,11 +1,11 @@
-def _is_apple_resource_file(file):
-    if file.extension in ("xcdatamodeld", "xcmappingmodel"):
+def _is_apple_resource_file(file, extensions_to_filter):
+    if file.extension in extensions_to_filter:
         return False
 
     return True
 
 def _resources_filegroup_impl(ctx):
-    files = [f for f in ctx.files.srcs if _is_apple_resource_file(f)]
+    files = [f for f in ctx.files.srcs if _is_apple_resource_file(file = f, extensions_to_filter = ctx.attr.extensions_to_filter)]
     return [
         DefaultInfo(
             files = depset(items = files),
@@ -16,16 +16,22 @@ resources_filegroup = rule(
     implementation = _resources_filegroup_impl,
     attrs = {
         "srcs": attr.label_list(allow_files = True, allow_empty = True),
+        "extensions_to_filter": attr.string_list(mandatory = True, allow_empty = True),
     },
     doc = """Wraps a set of srcs for use as `data` in an `objc_library` or `swift_library`,
 or `resources` in an `apple_resource_bundle`.
 """,
 )
 
-def wrap_resources_in_filegroup(name, srcs, **kwargs):
+def wrap_resources_in_filegroup(name, srcs, extensions_to_filter = [], **kwargs):
+    extensions_to_filter = list(extensions_to_filter)
+    for x in ("xcdatamodeld", "xcmappingmodel"):
+        if x not in extensions_to_filter:
+            extensions_to_filter.append(x)
     resources_filegroup(
         name = name,
         srcs = srcs,
+        extensions_to_filter = extensions_to_filter,
         **kwargs
     )
     return name


### PR DESCRIPTION
This way, our macros can filter out other directories that are causing clashes at the moment (`.lproj` dirs, I'm looking at you...)