### PR TITLE
Generate modulemaps for frameworks with only ObjC sources

### DIFF
--- a/rules/framework/framework_packaging.py
+++ b/rules/framework/framework_packaging.py
@@ -111,7 +111,7 @@ def _clean(framework_root, manifest_file, output_manifest_file):
         for d in dirs:
             path = os.path.join(root, d)
             if path not in dirs_to_keep:
-                os.rmdir(path)
+                shutil.rmtree(path)
         for f in files:
             path = os.path.join(root, f)
             if path not in files_to_keep:

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -395,7 +395,8 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
     cpp_libname = "%s_cpp" % name
 
     # TODO: remove framework if set
-    if namespace_is_module_name and not module_map and (objc_hdrs or objc_private_hdrs or swift_sources):
+    if namespace_is_module_name and not module_map and \
+       (objc_hdrs or objc_private_hdrs or swift_sources or objc_sources or cpp_sources):
         umbrella_header = library_tools["umbrella_header_generator"](
             name = name,
             library_tools = library_tools,

--- a/tests/app/ios/App/main.m
+++ b/tests/app/ios/App/main.m
@@ -1,4 +1,5 @@
 @import FW;
+@import OnlySources;
 
 int main() {
     exit(0);

--- a/tests/app/ios/BUILD.bazel
+++ b/tests/app/ios/BUILD.bazel
@@ -11,6 +11,11 @@ apple_framework(
     name = "Empty",
 )
 
+apple_framework(
+    name = "OnlySources",
+    srcs = glob(["OnlySources/*.m"]),
+)
+
 ios_application(
     name = "App",
     srcs = ["App/main.m"],
@@ -19,5 +24,6 @@ ios_application(
     deps = [
         ":Empty",
         ":FW",
+        ":OnlySources",
     ],
 )

--- a/tests/app/ios/OnlySources/OnlySources.m
+++ b/tests/app/ios/OnlySources/OnlySources.m
@@ -1,0 +1,7 @@
+@import Foundation;
+
+@interface OnlySources : NSObject
+@end
+
+@implementation OnlySources
+@end


### PR DESCRIPTION
Even if there are no headers.

This mirrors CocoaPods’ behavior around when modulemaps are generated (whenever there are any sources), and allows objc frameworks with only `.m`s to be imported (as pointless as that may seem).

Test added to verify behavior change