### PR TITLE
Pass visibility arg to test rule, not library rule

### DIFF
--- a/rules/test.bzl
+++ b/rules/test.bzl
@@ -11,6 +11,7 @@ _IOS_UNIT_TEST_KWARGS = [
     "args",
     "size",
     "timeout",
+    "visibility",
 ]
 
 def ios_unit_test(name, apple_library = apple_library, **kwargs):


### PR DESCRIPTION
When visibility is specified in the kwargs of ios_unit_test, it will now get passed as a kwarg to the unit_test rule, not the apple_library rule.