### PR TITLE
Handle podspecs that identify their swift_version supported as 5.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Select Xcode 11.2
         run: sudo xcode-select -s /Applications/Xcode_11.2.app
       - name: Build and Test
-        run: bazelisk test --local_test_jobs=2 //...
+        run: bazelisk test --local_test_jobs=1 //...
       - uses: actions/upload-artifact@v1
         if: failure()
         with:

--- a/tests/swift_version/BUILD.bazel
+++ b/tests/swift_version/BUILD.bazel
@@ -1,0 +1,36 @@
+load("//rules:framework.bzl", "apple_framework")
+
+SRCS = [
+    "empty.swift",
+]
+
+# Valid Versions
+
+[apple_framework(
+    name = "swift_version_" + version.replace(".", "_"),
+    srcs = SRCS,
+    swift_version = version,
+) for version in [
+    "4",
+    "4.0",
+    "4.0.0",
+    "4.2",
+    "4.2.0",
+    "5",
+    "5.0",
+    "5.1",
+]]
+
+# Invalid Versions (not tested, marked "manual")
+
+[apple_framework(
+    name = "swift_version_" + version.replace(".", "_"),
+    srcs = SRCS,
+    swift_version = version,
+    tags = ["manual"],
+) for version in [
+    "0",
+    "4.1",
+    "4.3.0",
+    "6",
+]]

--- a/tests/swift_version/empty.swift
+++ b/tests/swift_version/empty.swift
@@ -1,0 +1,1 @@
+private enum YouWish {}


### PR DESCRIPTION
We need to canonicalize the `swift_version` field to handle version 5.1, as SwiftC only accepts `4`, `4.2` or `5` as valid versions. We have reason to believe that only major versions will be used going forward. 