### PR TITLE
Add resources to ios_unit_test kwargs

### DIFF
--- a/rules/test.bzl
+++ b/rules/test.bzl
@@ -12,6 +12,7 @@ _IOS_UNIT_TEST_KWARGS = [
     "size",
     "timeout",
     "visibility",
+    "resources",
 ]
 
 def ios_unit_test(name, apple_library = apple_library, **kwargs):

--- a/tests/test/ios/BUILD.bazel
+++ b/tests/test/ios/BUILD.bazel
@@ -38,3 +38,4 @@ ios_unit_test(
     resources = ["resource-file.txt"],
     minimum_os_version = "11.0",
 )
+

--- a/tests/test/ios/BUILD.bazel
+++ b/tests/test/ios/BUILD.bazel
@@ -28,3 +28,13 @@ ios_unit_test(
     minimum_os_version = "12.0",
     test_host = "//rules/test_host_app:iOS-9.3-AppHost",
 )
+
+ios_unit_test(
+    name = "ResourcesAddedToUnitTestBundle",
+    srcs = [
+        "empty.m",
+        "empty.swift",
+    ],
+    resources = ["resource-file.txt"],
+    minimum_os_version = "11.0",
+)

--- a/tests/test/ios/BUILD.bazel
+++ b/tests/test/ios/BUILD.bazel
@@ -35,7 +35,6 @@ ios_unit_test(
         "empty.m",
         "empty.swift",
     ],
-    resources = ["resource-file.txt"],
     minimum_os_version = "11.0",
+    resources = ["resource-file.txt"],
 )
-

--- a/tests/test/ios/resource-file.txt
+++ b/tests/test/ios/resource-file.txt
@@ -1,0 +1,1 @@
+I am an example resource file that is meant to be added to a unit test bundle.


### PR DESCRIPTION
- Pass the `resources` argument from the `rules_ios` `ios_unit_test` macro into the `ios_unit_test` rule vended by `build_bazel/rules_apple`

- Ensure the `resources` argument from the `rules_ios` `ios_unit_test` macro does not get passed along to `swift_library` and `objc_library`