### PR TITLE
Enable Objective-C files in mixed-source frameworks to import the generated Swift header

### DIFF
--- a/tests/mixed-source/ios/BUILD.bazel
+++ b/tests/mixed-source/ios/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//rules:framework.bzl", "apple_framework")
+
+apple_framework(
+    name = "MixedSourceFramework",
+    srcs = glob(
+        [
+            "MixedSourceFramework/**/*.h",
+            "MixedSourceFramework/**/*.m",
+            "MixedSourceFramework/**/*.swift",
+        ],
+        exclude = ["MixedSourceFramework/MixedSourceFramework.h"],
+    ),
+    visibility = ["//visibility:public"],
+)

--- a/tests/mixed-source/ios/MixedSourceFramework/Logger/DoubleQuoteLogger.h
+++ b/tests/mixed-source/ios/MixedSourceFramework/Logger/DoubleQuoteLogger.h
@@ -1,0 +1,16 @@
+#ifndef DoubleQuoteLogger_h
+#define DoubleQuoteLogger_h
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DoubleQuoteLogger: NSObject
+
+- (void)logWithMessage:(NSString *)message;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif /* DoubleQuoteLogger_h */

--- a/tests/mixed-source/ios/MixedSourceFramework/Logger/DoubleQuoteLogger.m
+++ b/tests/mixed-source/ios/MixedSourceFramework/Logger/DoubleQuoteLogger.m
@@ -1,0 +1,15 @@
+#import "DoubleQuoteLogger.h"
+#import "MixedSourceFramework-Swift.h" // The `MixedSourceFramework-Swift.h` header allows
+                                       // Objective-C files from within a mixed-source framework
+                                       // to consume Swift files declared in the same framework.
+                                       //
+                                       // Here, we add no prefix to our `-Swift.h` import
+
+@implementation DoubleQuoteLogger
+
+- (void)logWithMessage:(NSString *)message {
+    SwiftLogger *swiftLogger = [[SwiftLogger alloc] init];
+    [swiftLogger swiftLog:message];
+}
+
+@end

--- a/tests/mixed-source/ios/MixedSourceFramework/Logger/DoubleQuoteNamespacedLogger.h
+++ b/tests/mixed-source/ios/MixedSourceFramework/Logger/DoubleQuoteNamespacedLogger.h
@@ -1,0 +1,16 @@
+#ifndef DoubleQuoteNamespacedLogger_h
+#define DoubleQuoteNamespacedLogger_h
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DoubleQuoteNamespacedLogger: NSObject
+
+- (void)logWithMessage:(NSString *)message;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif /* DoubleQuoteNamespacedLogger_h */

--- a/tests/mixed-source/ios/MixedSourceFramework/Logger/DoubleQuoteNamespacedLogger.m
+++ b/tests/mixed-source/ios/MixedSourceFramework/Logger/DoubleQuoteNamespacedLogger.m
@@ -1,0 +1,15 @@
+#import "DoubleQuoteNamespacedLogger.h"
+#import "MixedSourceFramework/MixedSourceFramework-Swift.h" // The `MixedSourceFramework-Swift.h` header allows
+                                                            // Objective-C files from within a mixed-source framework
+                                                            // to consume Swift files declared in the same framework.
+                                                            //
+                                                            // Here, we prefix our `-Swift.h` import with the namespace
+                                                            // of the framework itself.
+@implementation DoubleQuoteNamespacedLogger
+
+- (void)logWithMessage:(NSString *)message {
+    SwiftLogger *swiftLogger = [[SwiftLogger alloc] init];
+    [swiftLogger swiftLog:message];
+}
+
+@end

--- a/tests/mixed-source/ios/MixedSourceFramework/Logger/SwiftLogger.swift
+++ b/tests/mixed-source/ios/MixedSourceFramework/Logger/SwiftLogger.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+@objc
+public class SwiftLogger: NSObject {
+    @objc public override init () {}
+    @objc public func swiftLog(_ message: String) {
+        print(message)
+    }
+}
+

--- a/tests/mixed-source/ios/MixedSourceFramework/MixedSourceFramework.h
+++ b/tests/mixed-source/ios/MixedSourceFramework/MixedSourceFramework.h
@@ -1,0 +1,12 @@
+
+#import <Foundation/Foundation.h>
+#import <MixedSourceFramework/DoubleQuoteLogger.h>
+#import <MixedSourceFramework/DoubleQuoteNamespacedLogger.h>
+
+//! Project version number for MixedSourceFramework.
+FOUNDATION_EXPORT double MixedSourceFrameworkVersionNumber;
+
+//! Project version string for MixedSourceFramework.
+FOUNDATION_EXPORT const unsigned char MixedSourceFrameworkVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <MixedSourceFramework/PublicHeader.h>


### PR DESCRIPTION
Today when we use the `apple_framework` macro to create a `.framework` everything works fine… unless one of the framework's Objective-C files tries to import a Swift file.  Framework authors who import the framework's generated Swift header in their Objective-C source like so:

`#import "MySpecialFramework/MySpecialFramework-Swift.h`

or 

`#import "MySpecialFramework-Swift.h`

… will see a `clang` error when they try and compile those lines:

`fatal error: 'MySpecialFramework/MySpecialFramework-Swift.h' file not found`

or

`fatal error: 'MySpecialFramework-Swift.h' file not found`

This PR generates an additional header map that allows a framework's Objective-C files to be able to import the generated Swift header with either of the double-quoted `#import` statements listed above.