### PR TITLE
Actually prepend copts so they get passed to tools

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -194,14 +194,18 @@ _DefaultLibraryTools = {
     "fetch_default_xcconfig": _error_on_default_xcconfig,
 }
 
+def _prepend(list, other):
+    for item in reversed(other):
+        list.insert(0, item)
+
 def _prepend_copts(copts_struct, objc_copts, cc_copts, swift_copts, linkopts, ibtool_copts, momc_copts, mapc_copts):
-    objc_copts = copts_struct.objc_copts + objc_copts
-    cc_copts = copts_struct.cc_copts + cc_copts
-    swift_copts = copts_struct.swift_copts + swift_copts
-    linkopts = copts_struct.linkopts + linkopts
-    ibtool_copts = copts_struct.ibtool_copts + ibtool_copts
-    momc_copts = copts_struct.momc_copts + momc_copts
-    mapc_copts = copts_struct.mapc_copts + mapc_copts
+    _prepend(objc_copts, copts_struct.objc_copts)
+    _prepend(copts_struct.cc_copts, cc_copts)
+    _prepend(copts_struct.swift_copts, swift_copts)
+    _prepend(copts_struct.linkopts, linkopts)
+    _prepend(copts_struct.ibtool_copts, ibtool_copts)
+    _prepend(copts_struct.momc_copts, momc_copts)
+    _prepend(copts_struct.mapc_copts, mapc_copts)
 
 def _uppercase_string(s):
     return s.upper()

--- a/tests/xcconfig/BUILD.bazel
+++ b/tests/xcconfig/BUILD.bazel
@@ -39,4 +39,12 @@ apple_framework(
     },
 )
 
+apple_framework(
+    name = "wont_build_without_xcconfig",
+    non_arc_srcs = ["weak_property.m"],
+    xcconfig = {
+        "CLANG_ENABLE_OBJC_WEAK": "YES",
+    },
+)
+
 xcconfig_unit_test_suite()

--- a/tests/xcconfig/weak_property.m
+++ b/tests/xcconfig/weak_property.m
@@ -1,0 +1,8 @@
+@import Foundation;
+
+@interface ClassWithWeakProperty : NSObject
+@property (nonatomic, weak) NSObject *weakObject;
+@end
+
+@implementation ClassWithWeakProperty
+@end


### PR DESCRIPTION
Due to a prior refactor, `_prepend_copts` didn't actually prepend to
its parameters, but rather re-assigned.

This PR ensures that the list that gets passed through to the underlying
rules is modified.

This change is tested by adding a library that cannot compile without
the `copts` from its xcconfig applied. ObjC files using manual reference
counting cannot be compiled without the `-fobjc-weak` flag, which in
this case is only applied by the `CLANG_ENABLE_OBJC_WEAK` xcconfig.